### PR TITLE
Add QEMU amd64 Builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything
+*
+
+# Allow the output directory where the `img.qcow2` file resides
+!/output

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.RUNNER_LABEL }}
     env:
       NV_TIMESTAMP: ${{ needs.compute-matrix.outputs.TIMESTAMP }}
     steps:
@@ -47,6 +47,11 @@ jobs:
           role-to-assume: ${{ vars.VM_IMAGES_AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v4
+      - name: Setup `packer`
+        uses: hashicorp/setup-packer@main
+      - name: Setup QEMU/KVM
+        if: matrix.env == 'premise'
+        run: ci/setup-qemu-kvm.sh
       - name: Inject computed environment variables
         run: |
           IMAGE_NAME=$(ci/compute-image-name.sh)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,14 +94,18 @@ jobs:
         if: always() && matrix.env == 'aws'
         run: ci/clean-up-instance.sh
       - name: Login to ECR
-        if: matrix.ENV == 'premise' && github.event_name == 'push'
+        # TODO: uncomment this conditional
+        # if: matrix.ENV == 'premise' && github.event_name == 'push'
+        if: matrix.ENV == 'premise'
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
           mask-password: "true"
       - name: Build & push runner image
-        if: matrix.ENV == 'premise' && github.event_name == 'push'
+        # TODO: uncomment this conditional
+        # if: matrix.ENV == 'premise' && github.event_name == 'push'
+        if: matrix.ENV == 'premise'
         timeout-minutes: 30
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,3 +93,19 @@ jobs:
       - name: Clean Up Instance
         if: always() && matrix.env == 'aws'
         run: ci/clean-up-instance.sh
+      - name: Login to ECR
+        if: matrix.ENV == 'premise' && github.event_name == 'push'
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+          mask-password: "true"
+      - name: Build & push runner image
+        if: matrix.ENV == 'premise' && github.event_name == 'push'
+        timeout-minutes: 30
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          pull: true
+          tags: ${{ steps.ecr-login.outputs.registry }}/kubevirt-images:${{ env.NV_IMAGE_NAME }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,9 +94,7 @@ jobs:
         if: always() && matrix.env == 'aws'
         run: ci/clean-up-instance.sh
       - name: Login to ECR
-        # TODO: uncomment this conditional
-        # if: matrix.ENV == 'premise' && github.event_name == 'push'
-        if: matrix.ENV == 'premise'
+        if: matrix.ENV == 'premise' && github.event_name == 'push'
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
         with:
@@ -105,9 +103,7 @@ jobs:
         env:
           AWS_REGION: us-east-1 # public ECR is only available in us-east-1
       - name: Build & push runner image
-        # TODO: uncomment this conditional
-        # if: matrix.ENV == 'premise' && github.event_name == 'push'
-        if: matrix.ENV == 'premise'
+        if: matrix.ENV == 'premise' && github.event_name == 'push'
         timeout-minutes: 30
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.VM_IMAGES_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: us-east-1 # ECR public is only available in us-east-1
       - uses: actions/checkout@v4
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -102,8 +102,6 @@ jobs:
         with:
           registry-type: public
           mask-password: "true"
-        env:
-          AWS_DEFAULT_REGION: us-east-1 # ECR is only available in us-east-1
       - name: Build & push runner image
         # TODO: uncomment this conditional
         # if: matrix.ENV == 'premise' && github.event_name == 'push'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.VM_IMAGES_AWS_ROLE_ARN }}
-          aws-region: us-east-1 # ECR public is only available in us-east-1
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v4
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -102,6 +102,8 @@ jobs:
         with:
           registry-type: public
           mask-password: "true"
+        env:
+          AWS_REGION: us-east-1 # public ECR is only available in us-east-1
       - name: Build & push runner image
         # TODO: uncomment this conditional
         # if: matrix.ENV == 'premise' && github.event_name == 'push'
@@ -112,4 +114,4 @@ jobs:
           context: .
           push: true
           pull: true
-          tags: ${{ steps.ecr-login.outputs.registry }}/kubevirt-images:${{ env.NV_IMAGE_NAME }}
+          tags: ${{ steps.ecr-login.outputs.registry }}/nv-gha-runners/kubevirt-images:${{ env.NV_IMAGE_NAME }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,6 +102,8 @@ jobs:
         with:
           registry-type: public
           mask-password: "true"
+        env:
+          AWS_DEFAULT_REGION: us-east-1 # ECR is only available in us-east-1
       - name: Build & push runner image
         # TODO: uncomment this conditional
         # if: matrix.ENV == 'premise' && github.event_name == 'push'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# A Dockerfile to build `containerDisk` images for KubeVirt
+# see https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk
+FROM scratch
+COPY --chown=107:107 output/img.qcow2 /disk/

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ packer build -only="qemu*" .
 qemu-system-x86_64 \
     -enable-kvm \
     -m 2048 \
-    -drive file=output/build.qcow2,media=disk,if=virtio
+    -drive file=output/img.qcow2,media=disk,if=virtio
 ```

--- a/ci/clean-up-instance.sh
+++ b/ci/clean-up-instance.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# This script cleans up the EC2 instance created by Packer.
 set -euo pipefail
 
 INSTANCE_ID=$(

--- a/ci/compute-config-values.sh
+++ b/ci/compute-config-values.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -euo pipefail
-
 # This script outputs the values in config.yaml for the environment specified by
 # the `RUNNER_ENV` environment variable. The output is in the form of
 # `KEY=VALUE` pairs, one per line. This allows the output to be injected as
@@ -8,6 +6,8 @@ set -euo pipefail
 # uppercases the key. Here is an example when `RUNNER_ENV=aws`:
 # NV_DOMAIN=arc-eks
 # NV_PACKER_SOURCE=amazon-ebs
+set -euo pipefail
+
 
 yq -o json \
   '.[env(RUNNER_ENV)]' \

--- a/ci/compute-image-name.sh
+++ b/ci/compute-image-name.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This script computes the image name from the environment variables provided by
+# GitHub Actions.
 set -euo pipefail
 
 VARIANT=gpu

--- a/ci/compute-matrix.jq
+++ b/ci/compute-matrix.jq
@@ -8,6 +8,17 @@ def filter_excludes($entry; $excludes):
 def lists2dict($keys; $values):
   reduce range($keys | length) as $ind ({}; . + {($keys[$ind]): $values[$ind]});
 
+def compute_runner_label($entry):
+  if $entry.ENV == "aws" then
+    $entry + {"RUNNER_LABEL": "ubuntu-latest"}
+  elif $entry.ARCH == "amd64" then
+    $entry + {"RUNNER_LABEL": "linux-amd64-cpu72-metal"}
+  elif $entry.ARCH == "arm64" then
+    $entry + {"RUNNER_LABEL": "linux-arm64-cpu64-metal"}
+  else
+    "Unable to compute runner label\n" | halt_error
+  end;
+
 def compute_matrix($matrix):
   ($matrix.exclude // []) as $excludes |
   $matrix | del(.exclude) |
@@ -17,6 +28,7 @@ def compute_matrix($matrix):
   [
     combinations |
     lists2dict($matrix_keys; .) |
-    filter_excludes(.; $excludes)
+    filter_excludes(.; $excludes) |
+    compute_runner_label(.)
   ] |
   {include: .};

--- a/ci/compute-matrix.sh
+++ b/ci/compute-matrix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# This script computes the matrix for the GHAs matrix job.
 set -euo pipefail
 
-# This script computes the matrix for the GHAs matrix job.
 
 yq -o json \
   '.' \

--- a/ci/setup-qemu-kvm.sh
+++ b/ci/setup-qemu-kvm.sh
@@ -16,5 +16,5 @@ case "$(arch)" in
 esac
 
 sudo apt update
-sudo apt install "qemu-system-${QEMU_ARCH}" xorriso
+sudo apt install -y "qemu-system-${QEMU_ARCH}" xorriso
 sudo chmod 666 /dev/kvm

--- a/ci/setup-qemu-kvm.sh
+++ b/ci/setup-qemu-kvm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This script sets up QEMU/KVM on the host machine.
+set -euo pipefail
+
+case "$(arch)" in
+  x86_64)
+    QEMU_ARCH=x86
+    ;;
+  aarch64)
+    QEMU_ARCH=arm
+    ;;
+  *)
+    echo "Unsupported architecture: $(arch)"
+    exit 1
+    ;;
+esac
+
+sudo apt update
+sudo apt install "qemu-system-${QEMU_ARCH}" xorriso
+sudo chmod 666 /dev/kvm

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -16,6 +16,9 @@ ARCH:
 
 ENV:
   - aws
-  # - premise
+  - premise
 
-exclude: []
+exclude:
+  # TODO: get premise && arm64 working
+  - ENV: premise
+    ARCH: arm64

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -69,7 +69,7 @@ source "qemu" "ubuntu" {
   ssh_username     = "runner"
   ssh_password     = "runner"
   output_directory = "output"
-  vm_name          = "build.qcow2"
+  vm_name          = "img.qcow2"
   cd_files         = ["./cloud-init/*"]
   cd_label         = "cidata"
 


### PR DESCRIPTION
This PR adds QEMU amd64 builds to create images for KubeVirt.

Packer builds a `qcow2` image, which is then copied into a Docker image according to the KubeVirt instructions here: https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk.

The image is then pushed to our ECR registry.