### PR TITLE
Update root volume size on AMIs 

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,7 @@
 name: prs
 
 on:
-  push:
-    branches-ignore:
-      - main
+  pull_request:
 
 permissions:
   id-token: write

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -24,6 +24,14 @@ source "amazon-ebs" "ubuntu" {
       "group-name" : "default"
     }
   }
+  // TODO: remove this `launch_block_device_mappings` block in favor of specifying the EBS volume size
+  // when the instance is launched. This will save us $$ on the EBS snapshot sizes.
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 30
+    volume_type = "gp2"
+    delete_on_termination = true
+  }
   ssh_username         = "runner"
   ssh_password         = "runner"
   ssh_interface        = "session_manager"

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -27,9 +27,9 @@ source "amazon-ebs" "ubuntu" {
   // TODO: remove this `launch_block_device_mappings` block in favor of specifying the EBS volume size
   // when the instance is launched. This will save us $$ on the EBS snapshot sizes.
   launch_block_device_mappings {
-    device_name = "/dev/sda1"
-    volume_size = 30
-    volume_type = "gp2"
+    device_name           = "/dev/sda1"
+    volume_size           = 30
+    volume_type           = "gp2"
     delete_on_termination = true
   }
   ssh_username         = "runner"


### PR DESCRIPTION
This PR updates the root volume size on the AMIs that we create. This is necessary since the default size of 8GB is too small for our bare-metal instances to build QEMU images with.

This change should eventually be removed once we reconfigure the `arc-nv-runtime` to adjust the root device when launching the instance. This will allow us to save $$$ on the EBS snapshots associated with our AMIs.