### PR TITLE
Enable `arm64` QEMU builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           packer init .
           exec packer build \
-            -only="${NV_PACKER_SOURCE}*" \
+            -only="*${NV_PACKER_SOURCE}*" \
             -var "arch=${ARCH}" \
             -var "driver_version=${DRIVER_VERSION}" \
             -var "gh_run_id=${NV_RUN_ID}" \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,7 @@ jobs:
             -var "arch=${ARCH}" \
             -var "driver_version=${DRIVER_VERSION}" \
             -var "gh_run_id=${NV_RUN_ID}" \
+            -var "headless=true" \
             -var "image_name=${NV_IMAGE_NAME}" \
             -var "os=${OS}" \
             -var "runner_env=${RUNNER_ENV}" \

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.auto.pkrvars.hcl
 output
+*_VARS.fd
+cloud-init.iso

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The `qcow2` files are then packaged and published as a Docker image for use as a
 
 All images use the latest Ubuntu Jammy image as their base.
 
+## System Requirements for Building `qcow2` files
+
+Install the following packages:
+
+```sh
+sudo apt install qemu-system xorriso cloud-utils
+```
+
 ## Building `qcow2` Files Locally
 
 Create a `variables.auto.pkrvars.hcl` file and run `packer build`:

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -1,4 +1,16 @@
 build {
+  sources = ["source.null.qemu_dependencies"]
+
+  provisioner "shell-local" {
+    inline = [
+      "cp /usr/share/${lookup(local.uefi_imp, var.arch, "")}/${lookup(local.uefi_imp, var.arch, "")}_VARS.fd ${lookup(local.uefi_imp, var.arch, "")}_VARS.fd",
+      "cloud-localds cloud-init.iso cloud-init/{user,meta}-data"
+    ]
+    inline_shebang = "/bin/bash -e"
+  }
+}
+
+build {
   sources = [
     "source.amazon-ebs.ubuntu",
     "source.qemu.ubuntu",

--- a/ci/setup-qemu-kvm.sh
+++ b/ci/setup-qemu-kvm.sh
@@ -16,5 +16,5 @@ case "$(arch)" in
 esac
 
 sudo apt update
-sudo apt install -y "qemu-system-${QEMU_ARCH}" xorriso
+sudo apt install -y "qemu-system-${QEMU_ARCH}" xorriso cloud-utils
 sudo chmod 666 /dev/kvm

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -13,4 +13,19 @@ locals {
       : v if v != ""
     ]
   )
+
+  qemu_arch = {
+    "amd64" = "x86_64"
+    "arm64" = "aarch64"
+  }
+  uefi_imp = {
+    "amd64" = "OVMF"
+    "arm64" = "AAVMF"
+  }
+  qemu_machine = {
+    "amd64" = "ubuntu"
+    "arm64" = "virt"
+  }
+  output_directory = "output"
+  output_filename  = "img.qcow2"
 }

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -18,7 +18,4 @@ ENV:
   - aws
   - premise
 
-exclude:
-  # TODO: get premise && arm64 working
-  - ENV: premise
-    ARCH: arm64
+exclude: []

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -65,5 +65,5 @@ source "qemu" "ubuntu" {
   cd_files         = ["./cloud-init/*"]
   cd_label         = "cidata"
 
-  headless = true // comment this line to see the VM during local builds
+  headless = var.headless
 }

--- a/variables.auto.pkrvars.hcl.sample
+++ b/variables.auto.pkrvars.hcl.sample
@@ -1,5 +1,6 @@
 // arch = "amd64"
 // driver_version = "525.147.05"
+// headless = true
 // os = "linux"
 runner_version = "2.311.0"
 runner_env = "premise"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -32,6 +32,12 @@ variable "gh_run_id" {
   description = "The GitHub run ID. Used to clean up Packer resources in AWS."
 }
 
+variable "headless" {
+  type        = bool
+  default     = false
+  description = "Whether VNC viewer should not be launched."
+}
+
 variable "image_name" {
   type        = string
   default     = ""


### PR DESCRIPTION
This PR enables QEMU builds for `arm64`.

Among other online resources the MAAS example repository below was used as a reference for some of these changes:

- https://github.com/canonical/packer-maas/tree/main/ubuntu