### PR TITLE
Add `470` and `535` driver images

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -5,7 +5,9 @@ OS:
 DRIVER_VERSION:
   # keep this blank entry. an empty driver version corresponds to CPU machines
   - ""
+  - "470"
   - "525"
+  - "535"
 
 RUNNER_VERSION:
   - "2.311.0"

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -20,4 +20,6 @@ ENV:
   - aws
   - premise
 
-exclude: []
+exclude:
+  - ARCH: arm64
+    DRIVER_VERSION: "470"


### PR DESCRIPTION
This PR adds images for drivers `470` and `535`.

Driver `470` is the earliest current LTS branch and `535` is the latest current LTS branch.

source: https://docs.nvidia.com/datacenter/tesla/drivers/index.html#cuda-drivers