### PR TITLE
Add `check_event_type.sh` to runners

### DIFF
--- a/scripts/helpers/check_event_type.sh
+++ b/scripts/helpers/check_event_type.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] || [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ]; then
+  echo "Workflows triggered by \"${GITHUB_EVENT_NAME}\" events are not allowed to run on self-hosted runners."
+  exit 1
+fi
+
+echo "Event \"${GITHUB_EVENT_NAME}\" allowed to run on self-hosted runners."
+exit 0

--- a/scripts/helpers/runner.sh
+++ b/scripts/helpers/runner.sh
@@ -10,7 +10,8 @@ if [ ! -f "/jitconfig" ]; then
 fi
 
 ACTIONS_RUNNER_INPUT_JITCONFIG="$(cat /jitconfig)"
-export ACTIONS_RUNNER_INPUT_JITCONFIG
+ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/.check_event_type.sh
+export ACTIONS_RUNNER_INPUT_JITCONFIG ACTIONS_RUNNER_HOOK_JOB_STARTED
 
 echo "Removing JITConfig file"
 sudo rm -f /jitconfig

--- a/scripts/installers/runner.sh
+++ b/scripts/installers/runner.sh
@@ -20,6 +20,7 @@ rm -rf ./actions-runner.tar.gz
 
 # Copy scripts and services
 sudo cp "${NV_HELPER_SCRIPTS}/runner.sh" /runner.sh
+sudo cp "${NV_HELPER_SCRIPTS}/check_event_type.sh" /home/runner/.check_event_type.sh
 
 _UID=$(id -u)
 _GID=$(id -g)


### PR DESCRIPTION
This PR adds our `check_event_type.sh` script to our VM runners and configures it to run as a pre-start step by setting the `ACTIONS_RUNNER_HOOK_JOB_STARTED` environment variable's value to the path of the script.