### PR TITLE
Move `poweroff` to `systemd` unit file & add `renovate`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: build
 on:
   workflow_call:
     inputs:
-      skip_create_ami:
+      upload_artifacts:
         required: true
         type: boolean
 
@@ -79,7 +79,7 @@ jobs:
             -var "os=${OS}" \
             -var "runner_env=${RUNNER_ENV}" \
             -var "runner_version=${RUNNER_VERSION}" \
-            -var "skip_create_ami=${SKIP_CREATE_AMI}" \
+            -var "upload_ami=${UPLOAD_ARTIFACTS}" \
             -var "timestamp=${NV_TIMESTAMP}" \
             .
         env:
@@ -90,12 +90,12 @@ jobs:
           PACKER_SOURCE: ${{ matrix.packer_source }}
           RUNNER_ENV: ${{ matrix.ENV }}
           RUNNER_VERSION: ${{ matrix.RUNNER_VERSION }}
-          SKIP_CREATE_AMI: ${{ inputs.skip_create_ami }}
+          UPLOAD_ARTIFACTS: ${{ inputs.upload_artifacts }}
       - name: Clean Up Instance
         if: always() && matrix.env == 'aws'
         run: ci/clean-up-instance.sh
       - name: Login to ECR
-        if: matrix.ENV == 'premise' && github.event_name == 'push'
+        if: inputs.upload_artifacts
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
         with:
@@ -104,7 +104,7 @@ jobs:
         env:
           AWS_REGION: us-east-1 # public ECR is only available in us-east-1
       - name: Build & push runner image
-        if: matrix.ENV == 'premise' && github.event_name == 'push'
+        if: inputs.upload_artifacts
         timeout-minutes: 30
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,5 +17,5 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
     with:
-      skip_create_ami: false
+      upload_artifacts: true
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,5 +35,5 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
     with:
-      skip_create_ami: true
+      upload_artifacts: false
     secrets: inherit

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -10,6 +10,7 @@ DRIVER_VERSION:
   - "535"
 
 RUNNER_VERSION:
+  # renovate: repo=actions/runner
   - "2.311.0"
 
 ARCH:

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "regexManagers": [
+    {
+      "datasourceTemplate": "github-releases",
+      "fileMatch": ["^matrix.yaml$"],
+      "matchStrings": [
+        "\\s*#\\s*renovate:\\s*repo=(?<depName>.*?)\\s*-\\s*\"?(?<currentValue>.*?)\"?\\s"
+      ],
+      "extractVersion": "^v(?<version>.*)$"
+    }
+  ]
+}

--- a/scripts/helpers/runner.service
+++ b/scripts/helpers/runner.service
@@ -4,6 +4,7 @@ After=docker.service network.target cloud-final.service
 
 [Service]
 ExecStart=/runner.sh
+ExecStop=sudo poweroff
 User=runner
 KillMode=process
 KillSignal=SIGTERM

--- a/scripts/helpers/runner.sh
+++ b/scripts/helpers/runner.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 echo "Trying to fetch JITConfig"
 if [ ! -f "/jitconfig" ]; then
   echo "JITConfig not found. Exiting."
-  # TODO: either poweroff here or set a trap
-  # statement higher up to power off upon exit
   exit 1
 fi
 
@@ -18,5 +16,4 @@ sudo rm -f /jitconfig
 
 echo "Starting runner"
 cd "${HOME}"
-# TODO: Consider moving poweroff to systemd service
-./bin/runsvc.sh && sudo poweroff
+./bin/runsvc.sh

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -3,7 +3,7 @@ source "amazon-ebs" "ubuntu" {
   instance_type = local.instance_type
   region        = var.aws_region
 
-  skip_create_ami   = var.skip_create_ami
+  skip_create_ami   = !var.upload_ami
   shutdown_behavior = "terminate"
   user_data_file    = "./cloud-init/user-data"
 

--- a/variables.auto.pkrvars.hcl.sample
+++ b/variables.auto.pkrvars.hcl.sample
@@ -4,4 +4,4 @@
 // os = "linux"
 runner_version = "2.311.0"
 runner_env = "premise"
-// skip_create_ami = true
+// upload_ami = false

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -75,10 +75,10 @@ variable "runner_version" {
   }
 }
 
-variable "skip_create_ami" {
+variable "upload_ami" {
   type        = bool
-  default     = true
-  description = "Whether to skip creating the AMI. If true, the AMI will not be created."
+  default     = false
+  description = "Whether to create the AMI."
 }
 
 variable "timestamp" {


### PR DESCRIPTION
This PR moves the `poweroff` command for our runners to the `systemd` unit file.

It also adds `renovate` to keep the `RUNNER_VERSION` up-to-date.