### PR TITLE
Build images for new runner version `2.312.0`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -18,6 +18,7 @@ DRIVER_VERSION:
 
 RUNNER_VERSION:
   # renovate: repo=actions/runner
+  - "2.312.0"
   - "2.311.0"
 
 ARCH:


### PR DESCRIPTION
This PR adds the latest runner application to our images: https://github.com/actions/runner/releases/tag/v2.312.0.

We can test this. Once it's confirmed working, we can remove the previous runner version.