### PR TITLE
Add fluent-bit

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -68,6 +68,7 @@ build {
       "${path.root}/linux/installers/nvidia-container-toolkit.sh",
       "${path.root}/linux/installers/python.sh",
       "${path.root}/linux/installers/runner.sh",
+      "${path.root}/linux/installers/fluent-bit.sh",
 
       // Cleanup
       "${path.root}/linux/installers/cleanup.sh",

--- a/linux/context/fluent-bit/aws/aws.conf
+++ b/linux/context/fluent-bit/aws/aws.conf
@@ -1,0 +1,9 @@
+[FILTER]
+  Name              aws
+  Match             *
+  imds_version      v2
+  az                true
+  ec2_instance_id   true
+  ec2_instance_type true
+  ami_id            true
+  vpc_id            true

--- a/linux/context/fluent-bit/common.conf
+++ b/linux/context/fluent-bit/common.conf
@@ -1,0 +1,59 @@
+[FILTER]
+  Name  sysinfo
+  Match *
+
+[INPUT]
+  Name  cpu
+  Tag   cpu
+  Interval_Sec  5
+
+[OUTPUT]
+  Name    http
+  Match   cpu
+  Host    logs.${DOMAIN}.gha-runners.nvidia.com
+  Port    443
+  Uri     /cpu
+  Format  json
+  Tls     on
+
+[INPUT]
+  Name  kmsg
+  Tag   kernel
+
+[OUTPUT]
+  Name    http
+  Match   kernel
+  Host    logs.${DOMAIN}.gha-runners.nvidia.com
+  Port    443
+  Uri     /kernel
+  Format  json
+  Tls     on
+
+[INPUT]
+  Name  mem
+  Tag   memory
+  Interval_Sec 5
+
+[OUTPUT]
+  Name    http
+  Match   memory
+  Host    logs.${DOMAIN}.gha-runners.nvidia.com
+  Port    443
+  Uri     /memory
+  Format  json
+  Tls     on
+
+[INPUT]
+  Name  systemd
+  Tag   systemd
+  Systemd_Filter _SYSTEMD_UNIT=docker.service
+  Systemd_Filter _SYSTEMD_UNIT=runner.service
+
+[OUTPUT]
+  Name    http
+  Match   systemd
+  Host    logs.${DOMAIN}.gha-runners.nvidia.com
+  Port    443
+  Uri     /systemd
+  Format  json
+  Tls     on

--- a/linux/context/fluent-bit/fluent-bit.conf
+++ b/linux/context/fluent-bit/fluent-bit.conf
@@ -1,0 +1,4 @@
+[SERVICE]
+  log_level info
+
+@INCLUDE conf.d/*.conf

--- a/linux/context/fluent-bit/qemu/add_node_name.lua
+++ b/linux/context/fluent-bit/qemu/add_node_name.lua
@@ -1,0 +1,57 @@
+local downwardapi_file_path  = "/etc/downwardapi/labels"
+local node_name_label_key = "kubevirt.io/nodeName"
+local g_node_name = nil
+
+local function starts_with(str, start)
+   return str:sub(1, #start) == start
+end
+
+local function split(str, sep)
+  local t = {}
+  for s in string.gmatch(str, "([^" .. sep .. "]+)") do
+    table.insert(t, s)
+  end
+  return t
+end
+
+local function get_node_name()
+  if g_node_name ~= nil then
+    return g_node_name, nil
+  end
+
+  local downwardapi_file, err = io.open(downwardapi_file_path, "r")
+  if downwardapi_file == nil then
+    return nil, string.format("failed to open downwardapi file: %s", err)
+  end
+
+  for line in downwardapi_file:lines() do
+    if starts_with(line, node_name_label_key) then
+      local node_name_label = split(line, "=")
+      g_node_name = node_name_label[2]
+      g_node_name = g_node_name:sub(2, -2)
+      break
+    end
+  end
+
+  downwardapi_file:close()
+
+  if g_node_name == nil then
+    return nil, string.format("node name label not found in downwardapi file")
+  end
+
+  return g_node_name, nil
+end
+
+
+function add_node_name(tag, timestamp, record)
+  local node_name, err = get_node_name()
+  if node_name == nil then
+    io.stderr:write(string.format("failed to get node name: %s\n", err))
+    return 0, 0, 0
+  end
+
+  new_record = record
+  new_record["node_name"] = node_name
+
+  return 2, 0, new_record
+end

--- a/linux/context/fluent-bit/qemu/qemu.conf
+++ b/linux/context/fluent-bit/qemu/qemu.conf
@@ -1,0 +1,5 @@
+[FILTER]
+  Name    lua
+  Match   *
+  script  conf.d/add_node_name.lua
+  call    add_node_name

--- a/linux/installers/fluent-bit.sh
+++ b/linux/installers/fluent-bit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KEYRING="/usr/share/keyrings/fluentbit.gpg"
+APT="/etc/apt/sources.list.d/fluentbit.list"
+
+curl https://packages.fluentbit.io/fluentbit.key | sudo gpg --dearmor -o "${KEYRING}"
+sudo chmod a+r "${KEYRING}"
+
+CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
+
+echo \
+  "deb [signed-by=${KEYRING}] \
+  https://packages.fluentbit.io/ubuntu/${CODENAME} ${CODENAME} main" | \
+  sudo tee "${APT}"
+sudo apt-get update
+
+sudo apt-get install --no-install-recommends -y fluent-bit
+sudo systemctl enable fluent-bit
+
+DOMAIN=$(yq '.[env(NV_RUNNER_ENV)].domain' "${NV_CONTEXT_DIR}/config.yaml")
+export DOMAIN
+
+FLUENTBIT_CONFD="/etc/fluent-bit/conf.d"
+sudo mkdir -p "${FLUENTBIT_CONFD}"
+
+sudo cp "${NV_CONTEXT_DIR}/fluent-bit/fluent-bit.conf" /etc/fluent-bit/fluent-bit.conf
+envsubst < "${NV_CONTEXT_DIR}/fluent-bit/common.conf" | sudo tee "${FLUENTBIT_CONFD}/common.conf"
+
+if [ -d "${NV_CONTEXT_DIR}/fluent-bit/${NV_RUNNER_ENV}" ]; then
+  sudo cp -r "${NV_CONTEXT_DIR}/fluent-bit/${NV_RUNNER_ENV}"/* "${FLUENTBIT_CONFD}/"
+fi
+
+sudo systemctl restart fluent-bit
+
+sudo rm -rf "${APT}" "${KEYRING}"


### PR DESCRIPTION
This PR is adding `fluent-bit` to our runners

Each runner is pushing logs to an other `fluent-bit` instance running in each environment (`aws` and `qemu`)

We conditionally include a configuration directory for each environment:
- On `aws`, we use the `aws` filter to include metadata about the EC2 instance
- On `qemu`, we use a Lua script to include the node name in each log