### PR TITLE
Add git to PATH in Windows images

### DIFF
--- a/windows/context/verification.ps1
+++ b/windows/context/verification.ps1
@@ -5,5 +5,6 @@ jq --version
 yq --version
 git --version
 gh --version
+bash --version
 docker --version
 docker info

--- a/windows/installers/git.ps1
+++ b/windows/installers/git.ps1
@@ -13,5 +13,8 @@ Invoke-WebRequest -UseBasicParsing -Uri "${gitUri}" -OutFile "./git_setup.exe"
 # Use Start-Process to wait for installer to finish completely
 Start-Process -Wait -FilePath "./git_setup.exe" -ArgumentList "/SP- /VERYSILENT /NORESTART /NOCLOSEAPPLICATIONS"
 
+# For bash.exe, add 'C:\Program Files\Git\bin' to PATH
+[Environment]::SetEnvironmentVariable('Path', "$([Environment]::GetEnvironmentVariable('Path', 'Machine'));C:\Program Files\Git\bin", 'Machine')
+
 # Cleanup
 Remove-Item "./git_setup.exe"

--- a/windows/installers/git.ps1
+++ b/windows/installers/git.ps1
@@ -14,7 +14,7 @@ Invoke-WebRequest -UseBasicParsing -Uri "${gitUri}" -OutFile "./git_setup.exe"
 Start-Process -Wait -FilePath "./git_setup.exe" -ArgumentList "/SP- /VERYSILENT /NORESTART /NOCLOSEAPPLICATIONS"
 
 # For bash.exe, add 'C:\Program Files\Git\bin' to PATH
-[Environment]::SetEnvironmentVariable('Path', "$([Environment]::GetEnvironmentVariable('Path', 'Machine'));C:\Program Files\Git\bin", 'Machine')
+Set-MachineEnvironmentVariable -Append -Variable "Path" -Value "C:\Program Files\Git\bin"
 
 # Cleanup
 Remove-Item "./git_setup.exe"


### PR DESCRIPTION
Trying to add `C:\Program Files\Git\bin` to $PATH so the Windows images have bash.exe [like the GitHub hosted runners](https://github.com/actions/runner-images/blob/win22/20240211.1/images/windows/Windows2022-Readme.md#shells).

I don't know powershell, I have no idea if this will work, total shot in the dark.

cc: @wmaxey 