### PR TITLE
Remove runner version `2.312.0`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -18,7 +18,6 @@ DRIVER_VERSION:
 RUNNER_VERSION:
   # renovate: repo=actions/runner
   - "2.313.0"
-  - "2.312.0"
 
 ARCH:
   - amd64


### PR DESCRIPTION
This runner version can be removed after we upgrade to `2.313.0`.

[skip ci]