### PR TITLE
Add HyperV to Windows Images.

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -107,7 +107,8 @@ build {
     inline = [
       "mkdir ${local.context_directory}",
       "mkdir ${local.exe_directory}",
-      "Enable-WindowsOptionalFeature -NoRestart -Online -FeatureName Containers"
+      "Enable-WindowsOptionalFeature -NoRestart -Online -FeatureName Containers",
+      "Enable-WindowsOptionalFeature -NoRestart -Online -FeatureName Microsoft-Hyper-V"
     ]
   }
 


### PR DESCRIPTION
Fixes issues when building Windows 2019 images in the devcontainers repo.