### PR TITLE
Use `local` domain for on prem images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,4 +7,4 @@
 aws:
   domain: arc-eks
 qemu:
-  domain: arc-nvks
+  domain: local


### PR DESCRIPTION
This PR is updating the DNS domain to `local` for he on premise images. Once AWS images are also using the `local` domain, this logic can be removed