### PR TITLE
Add EC2 Name tag to fluent-bit logs and rename it to runner_name

### DIFF
--- a/linux/context/fluent-bit/aws/aws.conf
+++ b/linux/context/fluent-bit/aws/aws.conf
@@ -7,3 +7,10 @@
   ec2_instance_type true
   ami_id            true
   vpc_id            true
+  tags_enabled      true
+  tags_include      Name
+
+[FILTER]
+  Name   modify
+  Match  *
+  Rename Name runner_name


### PR DESCRIPTION
We add the EC2 `Name` tag in the logs and then rename it to `runner_name`. This will be used as the log key in CloudWatch