### PR TITLE
Disable systemd cgroups and improve fluent-bit logging

### DIFF
--- a/linux/context/dockerd.gpu.json
+++ b/linux/context/dockerd.gpu.json
@@ -1,4 +1,5 @@
 {
+  "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "default-runtime": "nvidia",
   "registry-mirrors": ["https://dc.$DOMAIN.gha-runners.nvidia.com"],
   "runtimes": {

--- a/linux/context/fluent-bit/common.conf
+++ b/linux/context/fluent-bit/common.conf
@@ -50,8 +50,6 @@
 [INPUT]
   Name  systemd
   Tag   systemd
-  Systemd_Filter _SYSTEMD_UNIT=docker.service
-  Systemd_Filter _SYSTEMD_UNIT=runner.service
 
 [OUTPUT]
   Name    http

--- a/linux/context/fluent-bit/fluent-bit.conf
+++ b/linux/context/fluent-bit/fluent-bit.conf
@@ -1,4 +1,4 @@
 [SERVICE]
-  log_level info
+  log_level warn
 
 @INCLUDE conf.d/*.conf


### PR DESCRIPTION
- To workaround an issue we are facing with GPU containers and systemd cgroups, we disable systemd cgroups in docker until we can fix the issue
- We remove the systemd filtering we have on fluent-bit logs so we can debug any issue related to any systemd service (like cloud-init)
- We reduce fluent-bit logs that are not really useful by setting the log level to warn