### PR TITLE
Add runner version `2.315.0`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -17,6 +17,7 @@ DRIVER_VERSION:
 
 RUNNER_VERSION:
   # renovate: repo=actions/runner
+  - "2.315.0"
   - "2.314.1"
 
 ARCH:


### PR DESCRIPTION
This PR adds runner version `2.315.0` to our matrix.