### PR TITLE
Remove old runner

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -18,7 +18,6 @@ DRIVER_VERSION:
 RUNNER_VERSION:
   # renovate: repo=actions/runner
   - "2.315.0"
-  - "2.314.1"
 
 ARCH:
   - amd64


### PR DESCRIPTION
This PR removes runner version `2.314.1` since it is no longer in use.

[skip ci]