### PR TITLE
Disable unattended-upgrades

### DIFF
--- a/linux/installers/apt.sh
+++ b/linux/installers/apt.sh
@@ -16,3 +16,8 @@ sudo apt install -y \
   unzip \
   wget \
   zip
+
+# Disable unattended-upgrades
+sudo systemctl disable --now unattended-upgrades
+echo 'APT::Periodic::Update-Package-Lists "0";' | sudo tee /etc/apt/apt.conf.d/20auto-upgrades
+echo 'APT::Periodic::Unattended-Upgrade "0";' | sudo tee -a /etc/apt/apt.conf.d/20auto-upgrades


### PR DESCRIPTION
`unattended-upgrades` must be disabled to prevent it from upgrading a critical package like the NVIDIA driver