### PR TITLE
Add runner version `2.316.1`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -19,6 +19,7 @@ DRIVER_VERSION:
 RUNNER_VERSION:
   # renovate: repo=actions/runner
   - "2.315.0"
+  - "2.316.1"
 
 ARCH:
   - amd64


### PR DESCRIPTION
This PR adds runner version `2.316.1` to our matrix