### PR TITLE
Remove runner version `2.315.0`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -18,7 +18,6 @@ DRIVER_VERSION:
 
 RUNNER_VERSION:
   # renovate: repo=actions/runner
-  - "2.315.0"
   - "2.316.1"
 
 ARCH:


### PR DESCRIPTION
This PR removes the `2.315.0` runner version from our matrix.