### PR TITLE
Move directives in runner unit file

### DIFF
--- a/linux/context/runner.service
+++ b/linux/context/runner.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=GHA Runner
 After=docker.service network.target cloud-final.service
+FailureAction=poweroff-immediate
+SuccessAction=poweroff-immediate
 
 [Service]
 ExecStart=/runner.sh
 ExecStop=sudo poweroff -ff
-FailureAction=poweroff-immediate
-SuccessAction=poweroff-immediate
 User=runner
 KillMode=process
 KillSignal=SIGTERM


### PR DESCRIPTION
This PR moves the `{Failure,Success}Action` directives from the `Service` section to the `Unit` section.

As per the docs below, they should be placed in the `Unit` section:

- https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html