### PR TITLE
Add runner version `2.317.0`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -18,6 +18,7 @@ DRIVER_VERSION:
 
 RUNNER_VERSION:
   # renovate: repo=actions/runner
+  - "2.317.0"
   - "2.316.1"
 
 ARCH:


### PR DESCRIPTION
This PR adds runner version `2.317.0` to our matrix.