### PR TITLE
Remove runner version `2.316.1`

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -19,7 +19,6 @@ DRIVER_VERSION:
 RUNNER_VERSION:
   # renovate: repo=actions/runner
   - "2.317.0"
-  - "2.316.1"
 
 ARCH:
   - amd64


### PR DESCRIPTION
This PR removes runner version `2.316.1` since it is no longer in use.

[skip ci]