### PR TITLE
Setup trap to poweroff instance in runner script

### DIFF
--- a/linux/context/runner.sh
+++ b/linux/context/runner.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+trap "sudo poweroff -ff" EXIT
+
 echo "Trying to fetch JITConfig"
 if [ ! -f "/jitconfig" ]; then
   echo "JITConfig not found. Exiting."


### PR DESCRIPTION
To ensure the instances are stopped when the runner script is exiting, this PR is adding a trap to run `sudo poweroff -ff` on exit in the runner script