### PR TITLE
Increase `aws_polling` values

### DIFF
--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -74,10 +74,10 @@ source "amazon-ebs" "windows" {
   instance_type = local.instance_type
   region        = var.aws_region
 
-  skip_create_ami   = !var.upload_ami
+  skip_create_ami = !var.upload_ami
   aws_polling {
     delay_seconds = 25
-    max_attempts = 60
+    max_attempts  = 60
   }
   shutdown_behavior = "terminate"
   # the `user_data` file for AWS must be wrapped in a <powershell> tag

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -75,6 +75,10 @@ source "amazon-ebs" "windows" {
   region        = var.aws_region
 
   skip_create_ami   = !var.upload_ami
+  aws_polling {
+    delay_seconds = 25
+    max_attempts = 60
+  }
   shutdown_behavior = "terminate"
   # the `user_data` file for AWS must be wrapped in a <powershell> tag
   user_data = <<-EOF


### PR DESCRIPTION
Lately, our Windows images in AWS have been throwing a `ResourceNotReady` error:

- https://github.com/nv-gha-runners/vm-images/actions/runs/9697044936/job/26775090346#step:7:262
- https://github.com/nv-gha-runners/vm-images/actions/runs/9697044936/job/26760297797#step:7:261

The link in the logs, https://developer.hashicorp.com/packer/integrations/hashicorp/amazon#resourcenotready-error, suggests that increasing the `aws_polling` values can resolve this.

Therefore, this PR increases the values of the `aws_polling` properties.

The default values are:

```hcl
aws_polling {
  delay_seconds = 15
  max_attempts = 40
}
```