### PR TITLE
Add support for copying AMIs to multiple regions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,30 +16,28 @@ defaults:
     shell: bash
 
 jobs:
-  compute-matrix:
+  compute-constants:
     runs-on: ubuntu-latest
     outputs:
-      MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
-      TIMESTAMP: ${{ steps.compute-matrix.outputs.TIMESTAMP }}
+      MATRIX: ${{ steps.compute-constants.outputs.MATRIX }}
+      TIMESTAMP: ${{ steps.compute-constants.outputs.TIMESTAMP }}
+      DEFAULT_AWS_REGION: ${{ steps.compute-constants.outputs.DEFAULT_AWS_REGION }}
+      BACKUP_AWS_REGIONS: ${{ steps.compute-constants.outputs.BACKUP_AWS_REGIONS }}
+      PUBLIC_ECR_REGION: ${{ steps.compute-constants.outputs.PUBLIC_ECR_REGION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Compute matrix
-        id: compute-matrix
-        run: |
-          export TZ='America/New_York'
-          MATRIX=$(ci/compute-matrix.sh)
-          TIMESTAMP=$(date +'%Y%m%d%H%M%S')
-          echo "MATRIX=${MATRIX}" | tee --append ${GITHUB_OUTPUT}
-          echo "TIMESTAMP=${TIMESTAMP}" | tee --append ${GITHUB_OUTPUT}
+      - name: Compute workflow constants
+        id: compute-constants
+        run: ci/compute-constants.sh
   build:
-    needs: compute-matrix
+    needs: compute-constants
     strategy:
-      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+      matrix: ${{ fromJSON(needs.compute-constants.outputs.MATRIX) }}
       fail-fast: false
     runs-on: ${{ matrix.RUNNER_LABEL }}
     env:
-      NV_TIMESTAMP: ${{ needs.compute-matrix.outputs.TIMESTAMP }}
+      NV_TIMESTAMP: ${{ needs.compute-constants.outputs.TIMESTAMP }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -53,10 +51,7 @@ jobs:
         if: matrix.ENV == 'qemu'
         run: ci/setup-qemu-kvm.sh
       - name: Inject computed environment variables
-        run: |
-          IMAGE_NAME=$(ci/compute-image-name.sh)
-          echo "NV_IMAGE_NAME=${IMAGE_NAME}" | tee --append "${GITHUB_ENV}"
-          echo "NV_RUN_ID=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" | tee --append "${GITHUB_ENV}"
+        run: ci/compute-variables.sh
         env:
           ARCH: ${{ matrix.ARCH }}
           DRIVER_VERSION: ${{ matrix.DRIVER_VERSION }}
@@ -76,6 +71,8 @@ jobs:
             -parallel-builds=1 \
             -only="*${OS}-${RUNNER_ENV}*" \
             -var "arch=${ARCH}" \
+            -var "backup_aws_regions=${BACKUP_AWS_REGIONS}" \
+            -var "default_aws_region=${DEFAULT_AWS_REGION}" \
             -var "driver_version=${DRIVER_VERSION}" \
             -var "gh_run_id=${NV_RUN_ID}" \
             -var "gh_token=${GH_TOKEN}" \
@@ -89,6 +86,8 @@ jobs:
             .
         env:
           ARCH: ${{ matrix.ARCH }}
+          BACKUP_AWS_REGIONS: ${{ needs.compute-constants.outputs.BACKUP_AWS_REGIONS }}
+          DEFAULT_AWS_REGION: ${{ needs.compute-constants.outputs.DEFAULT_AWS_REGION }}
           DRIVER_VERSION: ${{ matrix.DRIVER_VERSION }}
           GH_TOKEN: ${{ github.token }}
           OS: ${{ matrix.OS }}
@@ -110,7 +109,7 @@ jobs:
           registry-type: public
           mask-password: "true"
         env:
-          AWS_REGION: us-east-1 # public ECR is only available in us-east-1
+          AWS_REGION: ${{ needs.compute-constants.outputs.PUBLIC_ECR_REGION }}
       - name: Build & push runner image
         if: matrix.ENV == 'qemu' && inputs.upload_artifacts
         timeout-minutes: 30

--- a/ci/compute-constants.sh
+++ b/ci/compute-constants.sh
@@ -3,10 +3,7 @@
 set -euo pipefail
 
 # Compute the matrix
-MATRIX=$(
-  yq -o json '.' matrix.yaml | \
-  jq -c 'include "ci/compute-matrix"; compute_matrix(.)'
-)
+MATRIX=$(ci/compute-matrix.sh)
 
 # Compute the timestamp
 export TZ='America/New_York'

--- a/ci/compute-constants.sh
+++ b/ci/compute-constants.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# A script that computes the constants for our GHAs workflows
+set -euo pipefail
+
+# Compute the matrix
+MATRIX=$(
+  yq -o json '.' matrix.yaml | \
+  jq -c 'include "ci/compute-matrix"; compute_matrix(.)'
+)
+
+# Compute the timestamp
+export TZ='America/New_York'
+TIMESTAMP=$(date +'%Y%m%d%H%M%S')
+
+# Compute the regions
+DEFAULT_REGION=$(yq '.default_region' regions.yaml)
+BACKUP_REGIONS=$(yq '.backup_regions | join(",")' regions.yaml)
+PUBLIC_ECR_REGION=$(yq '.public_ecr_region' regions.yaml)
+
+cat <<EOF | tee --append "${GITHUB_OUTPUT:-/dev/null}"
+MATRIX=${MATRIX}
+TIMESTAMP=${TIMESTAMP}
+DEFAULT_AWS_REGION=${DEFAULT_REGION}
+BACKUP_AWS_REGIONS=${BACKUP_REGIONS}
+PUBLIC_ECR_REGION=${PUBLIC_ECR_REGION}
+EOF

--- a/ci/compute-image-name.sh
+++ b/ci/compute-image-name.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This script computes the image name from the environment variables provided by
+# GitHub Actions.
+set -euo pipefail
+
+VARIANT=gpu
+if [ -z "${DRIVER_VERSION}" ]; then
+  VARIANT=cpu
+fi
+
+IMAGE_NAME=$(
+  jq -nr \
+    --arg OS "${OS}" \
+    --arg VARIANT "${VARIANT}" \
+    --arg DRIVER_VERSION "${DRIVER_VERSION}" \
+    --arg ARCH "${ARCH}" \
+    --arg RUNNER_VERSION "${RUNNER_VERSION}" \
+  '[
+    $OS,
+    $VARIANT,
+    $DRIVER_VERSION,
+    $ARCH,
+    $RUNNER_VERSION
+  ] | map(select(length > 0)) | join("-")'
+)
+
+echo -n "${IMAGE_NAME}"

--- a/ci/compute-image-name.sh
+++ b/ci/compute-image-name.sh
@@ -11,12 +11,18 @@ fi
 export VARIANT
 
 IMAGE_NAME=$(
-  jq -nr '[
-    env.OS,
-    env.VARIANT,
-    env.DRIVER_VERSION,
-    env.ARCH,
-    env.RUNNER_VERSION
+  jq -nr \
+    --arg OS "${RUNNER_OS}" \
+    --arg VARIANT "${VARIANT}" \
+    --arg DRIVER_VERSION "${DRIVER_VERSION}" \
+    --arg ARCH "${RUNNER_ARCH}" \
+    --arg RUNNER_VERSION "${RUNNER_VERSION}" \
+  '[
+    $OS,
+    $VARIANT,
+    $DRIVER_VERSION,
+    $ARCH,
+    $RUNNER_VERSION
   ] | map(select(length > 0)) | join("-")'
 )
 

--- a/ci/compute-matrix.sh
+++ b/ci/compute-matrix.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# This script computes the matrix for the GHAs matrix job.
-set -euo pipefail
-
-
-yq -o json \
-  '.' \
-  matrix.yaml | \
-  jq -c 'include "ci/compute-matrix"; compute_matrix(.)'

--- a/ci/compute-matrix.sh
+++ b/ci/compute-matrix.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This script computes the matrix for the GHAs matrix job.
+set -euo pipefail
+
+
+yq -o json \
+  '.' \
+  matrix.yaml | \
+  jq -c 'include "ci/compute-matrix"; compute_matrix(.)'

--- a/ci/compute-variables.sh
+++ b/ci/compute-variables.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-# This script computes the image name from the environment variables provided by
-# GitHub Actions.
+# A script that computes the variables for our GHAs workflows
 set -euo pipefail
+
 
 VARIANT=gpu
 if [ -z "${DRIVER_VERSION}" ]; then
   VARIANT=cpu
 fi
-
-export VARIANT
 
 IMAGE_NAME=$(
   jq -nr \
@@ -26,4 +24,7 @@ IMAGE_NAME=$(
   ] | map(select(length > 0)) | join("-")'
 )
 
-echo -n "${IMAGE_NAME}"
+cat <<EOF | tee --append "${GITHUB_ENV:-/dev/null}"
+NV_IMAGE_NAME=${IMAGE_NAME}
+NV_RUN_ID=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+EOF

--- a/ci/compute-variables.sh
+++ b/ci/compute-variables.sh
@@ -2,27 +2,7 @@
 # A script that computes the variables for our GHAs workflows
 set -euo pipefail
 
-
-VARIANT=gpu
-if [ -z "${DRIVER_VERSION}" ]; then
-  VARIANT=cpu
-fi
-
-IMAGE_NAME=$(
-  jq -nr \
-    --arg OS "${RUNNER_OS}" \
-    --arg VARIANT "${VARIANT}" \
-    --arg DRIVER_VERSION "${DRIVER_VERSION}" \
-    --arg ARCH "${RUNNER_ARCH}" \
-    --arg RUNNER_VERSION "${RUNNER_VERSION}" \
-  '[
-    $OS,
-    $VARIANT,
-    $DRIVER_VERSION,
-    $ARCH,
-    $RUNNER_VERSION
-  ] | map(select(length > 0)) | join("-")'
-)
+IMAGE_NAME=$(ci/compute-image-name.sh)
 
 cat <<EOF | tee --append "${GITHUB_ENV:-/dev/null}"
 NV_IMAGE_NAME=${IMAGE_NAME}

--- a/gc/collectors/amis.py
+++ b/gc/collectors/amis.py
@@ -9,9 +9,9 @@ from mypy_boto3_ec2.paginator import (
 
 
 class AMIGarbageCollector(gc.GarbageCollector):
-    def __init__(self, current_images: list[str], dry_run: bool):
-        super().__init__("AMI Collector", dry_run)
-        self.ec2_client = boto3.client("ec2", region_name="us-east-2")
+    def __init__(self, current_images: list[str], region: str, dry_run: bool):
+        super().__init__("AMI Collector", region, dry_run)
+        self.ec2_client = boto3.client("ec2", region_name=region)
         self.current_images = current_images
         self.search_tag_name = "vm-images"
         self.search_tag_value = "true"

--- a/gc/collectors/ecr.py
+++ b/gc/collectors/ecr.py
@@ -7,9 +7,9 @@ from mypy_boto3_ecr_public.paginator import (
 
 
 class ECRGarbageCollector(gc.GarbageCollector):
-    def __init__(self, current_images: list[str], dry_run: bool):
-        super().__init__("ECR Collector", dry_run)
-        self.ecr_client = boto3.client("ecr-public", region_name="us-east-1")
+    def __init__(self, current_images: list[str], region: str, dry_run: bool):
+        super().__init__("ECR Collector", region, dry_run)
+        self.ecr_client = boto3.client("ecr-public", region_name=region)
         self.current_images = current_images
         self.repository_name = "kubevirt-images"
 

--- a/gc/collectors/gc.py
+++ b/gc/collectors/gc.py
@@ -2,8 +2,9 @@ from abc import ABC, abstractmethod
 
 
 class GarbageCollector(ABC):
-    def __init__(self, collector_name: str, dry_run: bool):
+    def __init__(self, collector_name: str, region: str, dry_run: bool):
         self.dry_run = dry_run
+        self.region = region
         self.collector_name = collector_name
         self.removal_action = dry_run and "Would have deleted" or "Deleting"
 
@@ -11,7 +12,9 @@ class GarbageCollector(ABC):
         print(f"{self.removal_action} {resource_name}: {resource_id}")
 
     def run(self) -> None:
-        print(f"Running {self.collector_name}: dry_run={self.dry_run}")
+        print(
+            f"Running {self.collector_name}: dry_run={self.dry_run}, region={self.region}"
+        )
         self._run()
 
     @abstractmethod

--- a/gc/main.py
+++ b/gc/main.py
@@ -1,6 +1,8 @@
 import argparse
 import subprocess
 import json
+import yaml
+from os import path
 from collectors.ecr import ECRGarbageCollector
 from collectors.amis import AMIGarbageCollector
 from collectors.gc import GarbageCollector
@@ -10,14 +12,20 @@ def load_current_images() -> list[str]:
     """
     Loads the currently supported images from the matrix and returns them as a list.
     """
+    compute_matrix_path = path.join(
+        path.dirname(__file__), "..", "ci", "compute-matrix.sh"
+    )
+    compute_image_name_path = path.join(
+        path.dirname(__file__), "..", "ci", "compute-image-name.sh"
+    )
     result = subprocess.run(
-        "ci/compute-matrix.sh", cwd="..", capture_output=True, check=True
+        compute_matrix_path, cwd="..", capture_output=True, check=True
     )
     matrix = json.loads(result.stdout.decode("utf-8"))["include"]
     images = []
     for entry in matrix:
         result = subprocess.run(
-            "ci/compute-image-name.sh",
+            compute_image_name_path,
             cwd="..",
             capture_output=True,
             env=entry,
@@ -44,7 +52,27 @@ if __name__ == "__main__":
         print("No current images found. Something's not right.")
         print("Exiting to prevent all images from being deleted from AWS.")
         exit(1)
-    for GC in [ECRGarbageCollector, AMIGarbageCollector]:
-        gc: GarbageCollector = GC(current_images, dry_run)
+
+    regions_path = path.join(path.dirname(__file__), "..", "regions.yaml")
+    with open(regions_path, "r") as file:
+        regions = yaml.safe_load(file)
+
+    ecr_collectors = [
+        ECRGarbageCollector(
+            current_images=current_images,
+            region=regions["public_ecr_region"],
+            dry_run=dry_run,
+        )
+    ]
+    ami_collectors = [
+        AMIGarbageCollector(
+            current_images=current_images,
+            region=region,
+            dry_run=dry_run,
+        )
+        for region in [regions["default_region"]] + regions["backup_regions"]
+    ]
+
+    for gc in ecr_collectors + ami_collectors:
         gc.run()
         print()

--- a/gc/requirements.txt
+++ b/gc/requirements.txt
@@ -4,3 +4,4 @@ types-python-dateutil
 black
 mypy
 pyyaml
+types-PyYAML

--- a/gc/requirements.txt
+++ b/gc/requirements.txt
@@ -3,3 +3,4 @@ boto3-stubs[boto3,ec2,ecr-public]
 types-python-dateutil
 black
 mypy
+pyyaml

--- a/regions.yaml
+++ b/regions.yaml
@@ -1,0 +1,7 @@
+# default region for Packer to provision AMIs to
+default_region: us-east-2
+# regions to copy AMIs to
+backup_regions:
+  - us-west-1
+# region required for public ECR images
+public_ecr_region: us-east-1

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -7,7 +7,8 @@ source "null" "preprovision" {
 source "amazon-ebs" "ubuntu" {
   ami_name      = local.image_id
   instance_type = local.instance_type
-  region        = var.aws_region
+  region        = var.default_aws_region
+  ami_regions = split(",", var.backup_aws_regions)
 
   skip_create_ami   = !var.upload_ami
   shutdown_behavior = "terminate"
@@ -72,7 +73,8 @@ source "qemu" "ubuntu" {
 source "amazon-ebs" "windows" {
   ami_name      = local.image_id
   instance_type = local.instance_type
-  region        = var.aws_region
+  region        = var.default_aws_region
+  ami_regions = split(",", var.backup_aws_regions)
 
   skip_create_ami = !var.upload_ami
   aws_polling {

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -8,7 +8,7 @@ source "amazon-ebs" "ubuntu" {
   ami_name      = local.image_id
   instance_type = local.instance_type
   region        = var.default_aws_region
-  ami_regions = split(",", var.backup_aws_regions)
+  ami_regions   = split(",", var.backup_aws_regions)
 
   skip_create_ami   = !var.upload_ami
   shutdown_behavior = "terminate"
@@ -74,7 +74,7 @@ source "amazon-ebs" "windows" {
   ami_name      = local.image_id
   instance_type = local.instance_type
   region        = var.default_aws_region
-  ami_regions = split(",", var.backup_aws_regions)
+  ami_regions   = split(",", var.backup_aws_regions)
 
   skip_create_ami = !var.upload_ami
   aws_polling {

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -9,9 +9,13 @@ variable "arch" {
   }
 }
 
-variable "aws_region" {
+variable "backup_aws_regions" {
   type        = string
-  default     = "us-east-2"
+  description = "A comma-separated list of the AWS regions to copy the AMIs to."
+}
+
+variable "default_aws_region" {
+  type        = string
   description = "The AWS region to provision EC2 instances in."
 }
 


### PR DESCRIPTION
This PR adds support for copying our AMIs to additional AWS regions.

The additional regions are defined in the new `regions.yaml` file.

The contents of `regions.yaml` are used in the following areas:

- in our `packer` configuration files (passed in as variables)
- in our garbage collection scripts