### PR TITLE
Increase `aws_polling` values again

### DIFF
--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -78,8 +78,8 @@ source "amazon-ebs" "windows" {
 
   skip_create_ami = !var.upload_ami
   aws_polling {
-    delay_seconds = 25
-    max_attempts  = 60
+    delay_seconds = 45
+    max_attempts  = 120
   }
   shutdown_behavior = "terminate"
   # the `user_data` file for AWS must be wrapped in a <powershell> tag


### PR DESCRIPTION
The latest changes in #68 were not enough to prevent Windows AMI build errors. The logs below show the issue happening again:

- https://github.com/nv-gha-runners/vm-images/actions/runs/9893897275/job/27330166398#step:7:266

To prevent the issue from occurring again, I've increased the values further.

These changes should cause `packer` to wait 90 minutes for the Windows AMI to be ready. This should (hopefully) be more than enough time.

Skipping CI since these changes don't affect the images themselves.

[skip ci]