### PR TITLE
Disable snap auto refresh

### DIFF
--- a/linux/installers/apt.sh
+++ b/linux/installers/apt.sh
@@ -21,3 +21,6 @@ sudo apt install -y \
 sudo systemctl disable --now unattended-upgrades
 echo 'APT::Periodic::Update-Package-Lists "0";' | sudo tee /etc/apt/apt.conf.d/20auto-upgrades
 echo 'APT::Periodic::Unattended-Upgrade "0";' | sudo tee -a /etc/apt/apt.conf.d/20auto-upgrades
+
+# Disable snap auto refresh
+sudo snap refresh --hold


### PR DESCRIPTION
To prevent any update while the runner is running, we should disable snap auto refresh feature