### PR TITLE
Use runfile to install NVIDIA driver and update driver versions

### DIFF
--- a/ci/compute-image-name.sh
+++ b/ci/compute-image-name.sh
@@ -8,17 +8,19 @@ if [ -z "${DRIVER_VERSION}" ]; then
   VARIANT=cpu
 fi
 
+DRIVER_VERSION_SHORT="${DRIVER_VERSION%%.*}"
+
 IMAGE_NAME=$(
   jq -nr \
     --arg OS "${OS}" \
     --arg VARIANT "${VARIANT}" \
-    --arg DRIVER_VERSION "${DRIVER_VERSION}" \
+    --arg DRIVER_VERSION_SHORT "${DRIVER_VERSION_SHORT}" \
     --arg ARCH "${ARCH}" \
     --arg RUNNER_VERSION "${RUNNER_VERSION}" \
   '[
     $OS,
     $VARIANT,
-    $DRIVER_VERSION,
+    $DRIVER_VERSION_SHORT,
     $ARCH,
     $RUNNER_VERSION
   ] | map(select(length > 0)) | join("-")'

--- a/linux/installers/nvidia-driver.sh
+++ b/linux/installers/nvidia-driver.sh
@@ -17,11 +17,6 @@ RUNFILE_NAME="NVIDIA-Linux-${ARCH}-${NV_DRIVER_VERSION}.run"
 RUNFILE_URL="https://download.nvidia.com/XFree86/Linux-${ARCH}/${NV_DRIVER_VERSION}/${RUNFILE_NAME}"
 RUNFILE_PATH="${TMP_DIR}/${RUNFILE_NAME}"
 
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends build-essential
-
 wget --no-verbose -O "${RUNFILE_PATH}" "${RUNFILE_URL}"
 sudo sh "${RUNFILE_PATH}" --no-questions --ui=none
 rm -rf "${TMP_DIR}"
-
-sudo apt-get purge build-essential --autoremove -y

--- a/linux/installers/nvidia-driver.sh
+++ b/linux/installers/nvidia-driver.sh
@@ -7,17 +7,21 @@ if [ "${NV_VARIANT}" != "gpu" ]; then
   exit 0
 fi
 
-KEYRING=cuda-keyring_1.1-1_all.deb
 ARCH=x86_64
-
 if [ "${NV_ARCH}" == "arm64" ]; then
-  ARCH=sbsa
+  ARCH=aarch64
 fi
 
-wget -q "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${ARCH}/${KEYRING}"
-sudo dpkg --install "${KEYRING}"
+TMP_DIR=$(mktemp -d)
+RUNFILE_NAME="NVIDIA-Linux-${ARCH}-${NV_DRIVER_VERSION}.run"
+RUNFILE_URL="https://download.nvidia.com/XFree86/Linux-${ARCH}/${NV_DRIVER_VERSION}/${RUNFILE_NAME}"
+RUNFILE_PATH="${TMP_DIR}/${RUNFILE_NAME}"
+
 sudo apt-get update
+sudo apt-get install -y --no-install-recommends build-essential
 
-sudo apt-get -y install "nvidia-driver-${NV_DRIVER_VERSION}"
+wget --no-verbose -O "${RUNFILE_PATH}" "${RUNFILE_URL}"
+sudo sh "${RUNFILE_PATH}" --no-questions --ui=none
+rm -rf "${TMP_DIR}"
 
-sudo dpkg --purge "$(dpkg -f "${KEYRING}" Package)"
+sudo apt-get purge build-essential --autoremove -y

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -12,6 +12,7 @@ OS:
 DRIVER_VERSION:
   # keep this blank entry. an empty driver version corresponds to CPU machines
   - ""
+  - "535.183.01"
   - "550.107.02"
   - "560.35.03"
 
@@ -32,6 +33,8 @@ exclude:
   - OS: windows
     ARCH: arm64
   # only make CPU images for windows
+  - OS: windows
+    DRIVER_VERSION: "535.183.01"
   - OS: windows
     DRIVER_VERSION: "550.107.02"
   - OS: windows

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -12,7 +12,6 @@ OS:
 DRIVER_VERSION:
   # keep this blank entry. an empty driver version corresponds to CPU machines
   - ""
-  - "470.57.02"
   - "550.107.02"
   - "560.35.03"
 
@@ -29,14 +28,10 @@ ENV:
   - qemu
 
 exclude:
-  - ARCH: arm64
-    DRIVER_VERSION: "470.57.02"
   # only use amd64 for windows
   - OS: windows
     ARCH: arm64
   # only make CPU images for windows
-  - OS: windows
-    DRIVER_VERSION: "470.57.02"
   - OS: windows
     DRIVER_VERSION: "550.107.02"
   - OS: windows

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -12,9 +12,9 @@ OS:
 DRIVER_VERSION:
   # keep this blank entry. an empty driver version corresponds to CPU machines
   - ""
-  - "470"
-  - "550"
-  - "560"
+  - "470.57.02"
+  - "550.107.02"
+  - "560.35.03"
 
 RUNNER_VERSION:
   # renovate: repo=actions/runner
@@ -30,17 +30,17 @@ ENV:
 
 exclude:
   - ARCH: arm64
-    DRIVER_VERSION: "470"
+    DRIVER_VERSION: "470.57.02"
   # only use amd64 for windows
   - OS: windows
     ARCH: arm64
   # only make CPU images for windows
   - OS: windows
-    DRIVER_VERSION: "470"
+    DRIVER_VERSION: "470.57.02"
   - OS: windows
-    DRIVER_VERSION: "550"
+    DRIVER_VERSION: "550.107.02"
   - OS: windows
-    DRIVER_VERSION: "560"
+    DRIVER_VERSION: "560.35.03"
   # only make AMI images for windows
   - OS: windows
     ENV: qemu

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -25,8 +25,8 @@ variable "driver_version" {
   description = "The NVIDIA driver version to install on the EC2 instance. If empty, no driver will be installed."
 
   validation {
-    condition     = can(regex("(^\\d{3}$|^$)", var.driver_version))
-    error_message = "The driver_version value must be an empty string or 3 digits."
+    condition     = can(regex("(^\\d{3}\\.\\d{2,3}\\.\\d{2,3}$|^$)", var.driver_version))
+    error_message = "The driver_version value must be an empty string or 3 groups of digits splitted by dots."
   }
 }
 


### PR DESCRIPTION
This PR is switching from using apt packages to runfiles to install the NVIDIA driver. This will help us to better control the driver version we want to install in our images. It's also updating the driver versions by removing EOL driver 470 and adding back driver 535