### PR TITLE
Reset GPU in runner startup script

### DIFF
--- a/linux/context/initialize_runner.sh
+++ b/linux/context/initialize_runner.sh
@@ -2,6 +2,12 @@
 
 set -eu
 
+# reset GPU if there is one
+if command -v "nvidia-smi" &> /dev/null; then
+  sudo nvidia-smi --gpu-reset
+  nvidia-smi
+fi
+
 # these strings are case-sensitive and should match the case of the GH org
 CLOUD_ONLY_ORGS=(
   "dask-contrib"

--- a/linux/installers/docker.sh
+++ b/linux/installers/docker.sh
@@ -42,6 +42,10 @@ if [ "${NV_RUNNER_ENV}" == "qemu" ]; then
 fi
 
 sudo systemctl restart docker
-docker info
+sudo docker info
+
+# Ensure user is part of docker group
+sudo groupadd docker -f
+sudo usermod -aG docker "${USER}"
 
 sudo rm -rf "${APT}" "${KEYRING}"

--- a/linux/installers/nvidia-container-toolkit.sh
+++ b/linux/installers/nvidia-container-toolkit.sh
@@ -32,4 +32,4 @@ sudo nvidia-ctk runtime configure --runtime docker --set-as-default
 # sudo cp "${NV_CONTEXT_DIR}/nvidia-cdi.rules" /lib/udev/rules.d/71-nvidia-cdi.rules
 
 sudo systemctl restart docker
-docker info
+sudo docker info


### PR DESCRIPTION
Reset GPU in runner startup script if there is a GPU available. This should prevent issues if a previous job left the GPU in a bad state. This PR is also fixing a docker permission issue