### PR TITLE
Fix AMI tags for GPU images

### DIFF
--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -2,7 +2,7 @@ locals {
   ami_tags = {
     for k, v in {
       "arch"           = var.arch
-      "driver-version" = var.driver_version
+      "driver-version" = split(".", var.driver_version)[0]
       "os"             = var.os
       "runner-version" = var.runner_version
       "variant"        = local.variant


### PR DESCRIPTION
Only use major driver version in tags for GPU amis