### PR TITLE
Prevent kernel upgrades when upgrading all packages

### DIFF
--- a/linux/installers/apt.sh
+++ b/linux/installers/apt.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 echo 'APT::Update::Error-Mode "any";' | sudo tee /etc/apt/apt.conf.d/warnings-as-errors
 
+# Prevent kernel upgrades
+sudo apt-mark hold "$(uname -r)"
+
 sudo apt update
 sudo apt upgrade -y
 


### PR DESCRIPTION
As we are using a `runfile` to install the NVIDIA driver, we must ensure we don't upgrade the driver, otherwise the driver will be built/installed for the previous kernel version and will not be loaded when the VM is started

Example of failures: https://github.com/nv-gha-runners/runner-testing/actions/runs/10993397154/job/30519963334#step:2:5
Kernel upgrade: https://github.com/nv-gha-runners/vm-images/actions/runs/10924064302/job/30325032095#step:8:131
Runfile building for the wrong kernel version: https://github.com/nv-gha-runners/vm-images/actions/runs/10924064302/job/30325032095#step:8:656