### PR TITLE
Enable persistence mode for GPUs

### DIFF
--- a/linux/context/nvidia-persistenced-override.conf
+++ b/linux/context/nvidia-persistenced-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --persistence-mode --verbose

--- a/linux/installers/nvidia-driver.sh
+++ b/linux/installers/nvidia-driver.sh
@@ -28,3 +28,8 @@ options nvidia NVreg_NvLinkDisable=1
 options nvidia NVreg_OpenRmEnableUnsupportedGpus=1
 EOF"
 sudo update-initramfs -u
+
+# Set persistence mode on
+OVERRIDE_DIR="/etc/systemd/system/nvidia-persistenced.service.d"
+sudo mkdir -p "${OVERRIDE_DIR}"
+sudo cp "${NV_CONTEXT_DIR}/nvidia-persistenced-override.conf" "${OVERRIDE_DIR}/override.conf"


### PR DESCRIPTION
To prevent some GSP timeouts, we need to enable persistence mode on GPUs