### PR TITLE
Publish legacy and open driver flavors images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,7 @@ jobs:
         env:
           ARCH: ${{ matrix.ARCH }}
           DRIVER_VERSION: ${{ matrix.DRIVER_VERSION }}
+          DRIVER_FLAVOR: ${{ matrix.DRIVER_FLAVOR }}
           OS: ${{ matrix.OS }}
           RUNNER_ENV: ${{ matrix.ENV }}
           RUNNER_VERSION: ${{ matrix.RUNNER_VERSION }}
@@ -75,6 +76,7 @@ jobs:
             -var "backup_aws_regions=${BACKUP_AWS_REGIONS}" \
             -var "default_aws_region=${DEFAULT_AWS_REGION}" \
             -var "driver_version=${DRIVER_VERSION}" \
+            -var "driver_flavor=${DRIVER_FLAVOR}" \
             -var "gh_run_id=${NV_RUN_ID}" \
             -var "gh_token=${GH_TOKEN}" \
             -var "headless=true" \
@@ -90,6 +92,7 @@ jobs:
           BACKUP_AWS_REGIONS: ${{ needs.compute-constants.outputs.BACKUP_AWS_REGIONS }}
           DEFAULT_AWS_REGION: ${{ needs.compute-constants.outputs.DEFAULT_AWS_REGION }}
           DRIVER_VERSION: ${{ matrix.DRIVER_VERSION }}
+          DRIVER_FLAVOR: ${{ matrix.DRIVER_FLAVOR }}
           GH_TOKEN: ${{ github.token }}
           OS: ${{ matrix.OS }}
           PACKER_GITHUB_API_TOKEN: ${{ github.token }}

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -39,6 +39,7 @@ build {
       "GH_TOKEN=${var.gh_token}",
       "NV_ARCH=${var.arch}",
       "NV_DRIVER_VERSION=${var.driver_version}",
+      "NV_DRIVER_FLAVOR=${var.driver_flavor}",
       "NV_CONTEXT_DIR=${local.context_directory}",
       "NV_EXE_DIR=${local.exe_directory}",
       "NV_RUNNER_ENV=${var.runner_env}",

--- a/ci/compute-image-name.sh
+++ b/ci/compute-image-name.sh
@@ -13,12 +13,14 @@ IMAGE_NAME=$(
     --arg OS "${OS}" \
     --arg VARIANT "${VARIANT}" \
     --arg DRIVER_VERSION "${DRIVER_VERSION}" \
+    --arg DRIVER_FLAVOR "${DRIVER_FLAVOR}" \
     --arg ARCH "${ARCH}" \
     --arg RUNNER_VERSION "${RUNNER_VERSION}" \
   '[
     $OS,
     $VARIANT,
     $DRIVER_VERSION,
+    $DRIVER_FLAVOR,
     $ARCH,
     $RUNNER_VERSION
   ] | map(select(length > 0)) | join("-")'

--- a/linux/installers/nvidia-driver.sh
+++ b/linux/installers/nvidia-driver.sh
@@ -8,17 +8,22 @@ if [ "${NV_VARIANT}" != "gpu" ]; then
 fi
 
 KEYRING=cuda-keyring_1.1-1_all.deb
-ARCH=x86_64
 
+ARCH=x86_64
 if [ "${NV_ARCH}" == "arm64" ]; then
   ARCH=sbsa
+fi
+
+DRIVER_PKG_NAME="nvidia-driver-${NV_DRIVER_VERSION}-server"
+if [ "${NV_DRIVER_FLAVOR}" == "open" ]; then
+  DRIVER_PKG_NAME="nvidia-driver-${NV_DRIVER_VERSION}-server-open"
 fi
 
 wget -q "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${ARCH}/${KEYRING}"
 sudo dpkg --install "${KEYRING}"
 sudo apt-get update
 
-sudo apt-get -y install "nvidia-driver-${NV_DRIVER_VERSION}-server-open"
+sudo apt-get -y install "${DRIVER_PKG_NAME}"
 
 sudo dpkg --purge "$(dpkg -f "${KEYRING}" Package)"
 

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -3,6 +3,7 @@ locals {
     for k, v in {
       "arch"           = var.arch
       "driver-version" = var.driver_version
+      "driver-flavor"  = var.driver_flavor
       "os"             = var.os
       "runner-version" = var.runner_version
       "variant"        = local.variant

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -15,6 +15,11 @@ DRIVER_VERSION:
   - "535"
   - "550"
 
+DRIVER_FLAVOR:
+  - ""
+  - "legacy"
+  - "open"
+
 RUNNER_VERSION:
   # renovate: repo=actions/runner
   - "2.319.1"
@@ -39,3 +44,13 @@ exclude:
   # only make AMI images for windows
   - OS: windows
     ENV: qemu
+  # don't set DRIVER_FLAVOR for CPU images
+  - DRIVER_VERSION: ""
+    DRIVER_FLAVOR: "legacy"
+  - DRIVER_VERSION: ""
+    DRIVER_FLAVOR: "open"
+  # ensure DRIVER_FLAVOR is set if DRIVER_VERSION is set
+  - DRIVER_VERSION: "535"
+    DRIVER_FLAVOR: ""
+  - DRIVER_VERSION: "550"
+    DRIVER_FLAVOR: ""

--- a/variables.auto.pkrvars.hcl.sample
+++ b/variables.auto.pkrvars.hcl.sample
@@ -1,5 +1,6 @@
 // arch = "amd64"
 // driver_version = "525.147.05"
+// driver_flavor = "open"
 // gh_token = ""
 // headless = true
 image_name = "local-image"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -30,6 +30,17 @@ variable "driver_version" {
   }
 }
 
+variable "driver_flavor" {
+  type        = string
+  default     = ""
+  description = "The NVIDIA driver flavor to install."
+
+  validation {
+    condition     = can(regex("^(open|legacy|)$", var.driver_flavor))
+    error_message = "The driver_flavor value must be either 'open' or 'legacy'."
+  }
+}
+
 variable "gh_run_id" {
   type        = string
   default     = ""


### PR DESCRIPTION
To support all types of GPUs in our runners, we need to publish images for both `legacy` and `open` driver version. This PR is adding a new variable `DRIVER_FLAVOR` to support this