### PR TITLE
Install and configure watchdog on amd64 images

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -65,6 +65,7 @@ build {
       "${path.root}/linux/installers/python.sh",
       "${path.root}/linux/installers/runner.sh",
       "${path.root}/linux/installers/fluent-bit.sh",
+      "${path.root}/linux/installers/watchdog.sh",
 
       // Cleanup
       "${path.root}/linux/installers/cleanup.sh",

--- a/linux/installers/watchdog.sh
+++ b/linux/installers/watchdog.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# Watchdog is only for qemu and amd64 images
+if [ "${NV_RUNNER_ENV}" != "qemu" ] || [ "${NV_ARCH}" == "arm64" ]; then
+  exit 0
+fi
+
+# Install watchdog kernel modules and package
+# --allow-change-held-packages is required as kernel packages are marked as hold
+sudo apt install --no-install-recommends -y --allow-change-held-packages \
+  "linux-modules-extra-$(uname -r)" \
+  watchdog
+
+# Configure watchdog daemon
+sudo sed -i 's/#watchdog-device/watchdog-device/g' /etc/watchdog.conf
+sudo sed -i 's/#log-dir/log-dir/g' /etc/watchdog.conf
+sudo sed -i 's/run_watchdog=.*/run_watchdog=1/g' /etc/default/watchdog
+sudo sed -i 's/watchdog_module=".*"/watchdog_module="i6300esb"/g' /etc/default/watchdog
+
+# Enable watchdog daemon
+sudo systemctl enable watchdog


### PR DESCRIPTION
This PR is installing and configuring a watchdog daemon. This daemon is in charge to send a heartbeat on the watchdog device to notify that the VM is still alive. This only applies to amd64 and qemu images