### PR TITLE
Fix logic error with AMI GC

### DIFF
--- a/gc/collectors/amis.py
+++ b/gc/collectors/amis.py
@@ -72,7 +72,6 @@ class AMIGarbageCollector(gc.GarbageCollector):
                 if image_name:
                     if branch_name:
                         ami_groups[branch_name][image_name].append(ami)
-                        break
                     else:
                         expired_amis.append(ami)
 


### PR DESCRIPTION
Remove a stray `break` that was causing AMIs to not be GC'd.