### PR TITLE
Update Fluent Bit configs

### DIFF
--- a/linux/context/fluent-bit/aws/aws.conf
+++ b/linux/context/fluent-bit/aws/aws.conf
@@ -1,6 +1,6 @@
 [FILTER]
   Name              aws
-  Match             *
+  Match             logs
   imds_version      v2
   az                true
   ec2_instance_id   true
@@ -12,5 +12,5 @@
 
 [FILTER]
   Name   modify
-  Match  *
+  Match  logs
   Rename Name runner_name

--- a/linux/context/fluent-bit/common.conf
+++ b/linux/context/fluent-bit/common.conf
@@ -1,6 +1,6 @@
 [FILTER]
   Name                sysinfo
-  Match               *
+  Match               logs
   hostname_key        hostname
   kernel_version_key  kernel_version
   os_name_key         os_name
@@ -8,54 +8,27 @@
 
 [INPUT]
   Name  cpu
-  Tag   cpu
+  Tag   logs
   Interval_Sec  5
-
-[OUTPUT]
-  Name    http
-  Match   cpu
-  Host    logs.local.gha-runners.nvidia.com
-  Port    443
-  Uri     /cpu
-  Format  json
-  Tls     on
 
 [INPUT]
   Name  kmsg
-  Tag   kernel
-
-[OUTPUT]
-  Name    http
-  Match   kernel
-  Host    logs.local.gha-runners.nvidia.com
-  Port    443
-  Uri     /kernel
-  Format  json
-  Tls     on
+  Tag   logs
 
 [INPUT]
   Name  mem
-  Tag   memory
+  Tag   logs
   Interval_Sec 5
-
-[OUTPUT]
-  Name    http
-  Match   memory
-  Host    logs.local.gha-runners.nvidia.com
-  Port    443
-  Uri     /memory
-  Format  json
-  Tls     on
 
 [INPUT]
   Name  systemd
-  Tag   systemd
+  Tag   logs
 
 [OUTPUT]
   Name    http
-  Match   systemd
+  Match   logs
   Host    logs.local.gha-runners.nvidia.com
   Port    443
-  Uri     /systemd
+  Uri     /logs
   Format  json
   Tls     on

--- a/linux/context/fluent-bit/qemu/qemu.conf
+++ b/linux/context/fluent-bit/qemu/qemu.conf
@@ -1,5 +1,5 @@
 [FILTER]
   Name    lua
-  Match   *
+  Match   logs
   script  conf.d/add_node_name.lua
   call    add_node_name


### PR DESCRIPTION
This PR updates the Fluent Bit configuration for the VMs.

The goal of these changes is to allow the Fluent Bit aggregator to distinguish between log records and @msarahan's new trace records. Grouping all of the existing records under the `log` tag ensures that the aggregator only sends records matching this tag to CloudWatch.

Currently, there doesn't seem to be a need to tag records more granuarly than `logs` vs. `traces`. However, if the need arises in the future, we can always use Fluent Bit's wildcard or regex matching features, described here https://docs.fluentbit.io/manual/concepts/data-pipeline/router, with tags like `logs.cpu`, `logs.mem`, `logs.systemd`, etc. Corresponding matches can be made with `logs.*`, `logs.(cpu|mem)`, etc.