### PR TITLE
Update Fluent Bit hostname to `fb.local`

### DIFF
--- a/linux/context/fluent-bit/common.conf
+++ b/linux/context/fluent-bit/common.conf
@@ -27,7 +27,7 @@
 [OUTPUT]
   Name    http
   Match   logs
-  Host    logs.local.gha-runners.nvidia.com
+  Host    fb.local.gha-runners.nvidia.com
   Port    443
   Uri     /logs
   Format  json

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -13,7 +13,6 @@ DRIVER_VERSION:
   # keep this blank entry. an empty driver version corresponds to CPU machines
   - ""
   - "535"
-  - "550"
   - "565"
 
 DRIVER_FLAVOR:
@@ -41,8 +40,6 @@ exclude:
   - OS: windows
     DRIVER_VERSION: "535"
   - OS: windows
-    DRIVER_VERSION: "550"
-  - OS: windows
     DRIVER_VERSION: "565"
   # only make AMI images for windows
   - OS: windows
@@ -54,8 +51,6 @@ exclude:
     DRIVER_FLAVOR: "open"
   # ensure DRIVER_FLAVOR is set if DRIVER_VERSION is set
   - DRIVER_VERSION: "535"
-    DRIVER_FLAVOR: ""
-  - DRIVER_VERSION: "550"
     DRIVER_FLAVOR: ""
   - DRIVER_VERSION: "565"
     DRIVER_FLAVOR: ""


### PR DESCRIPTION
This PR is updating the Fluent Bit hostname from `logs.local` to `fb.local`.

This PR is also dropping driver `550` images to reduce the build matrix. This version is not used anymore.