### PR TITLE
Publish new `actions/runner` images automatically

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - test-**
+      - deps-actions-runner-2.x
 
 permissions:
   id-token: write

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "branchPrefix": "deps-",
   "extends": ["config:base"],
   "customManagers": [
     {


### PR DESCRIPTION
This PR makes a few changes that enable images with new versions of `actions/runner` to be published automatically.

The changes include:

- changing the `renovate` branch prefix from its default (`renovate/`) to `deps-`
- changing the VM image deploy workflow to trigger on pushes to `deps-actions-runner-2.x`

[skip ci]