### PR TITLE
Add back the trigger to publish images if branch starts with test-

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - deps-actions-runner-[0-9]*
+      - test-**
 
 permissions:
   id-token: write


### PR DESCRIPTION
This trigger was removed in https://github.com/nv-gha-runners/vm-images/pull/104

[skip ci]