### PR TITLE
Move runner version outside of `matrix.yaml`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,8 @@ jobs:
           DRIVER_FLAVOR: ${{ matrix.DRIVER_FLAVOR }}
           OS: ${{ matrix.OS }}
           RUNNER_ENV: ${{ matrix.ENV }}
-          RUNNER_VERSION: ${{ matrix.RUNNER_VERSION }}
+          # renovate: repo=actions/runner
+          RUNNER_VERSION: "2.321.0"
         # The `exec` command is used to help forward signals to the child process.
         # This helps ensure Packer's AWS resources get removed when the job is cancelled.
         #

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -20,10 +20,6 @@ DRIVER_FLAVOR:
   - "legacy"
   - "open"
 
-RUNNER_VERSION:
-  # renovate: repo=actions/runner
-  - "2.321.0"
-
 ARCH:
   - amd64
   - arm64

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "branchPrefix": "deps-",
-  "extends": ["config:base"],
+  "extends": [
+    "config:base"
+  ],
   "customManagers": [
     {
       "customType": "regex",
       "datasourceTemplate": "github-releases",
-      "fileMatch": ["^matrix.yaml$"],
+      "fileMatch": [
+        "^.github/workflows/build.yaml$"
+      ],
       "matchStrings": [
-        "\\s*#\\s*renovate:\\s*repo=(?<depName>.*?)\\s*-\\s*\"?(?<currentValue>.*?)\"?\\s"
+        "# renovate: repo=(?<depName>.*?)\\s+\\a+: \"?(?<currentValue>.*?)\"?"
       ]
     }
   ]


### PR DESCRIPTION
Since the runner version is no longer a matrix value, this PR moves it outside of the `matrix.yaml` file.