### PR TITLE
vector: only collect required metrics

### DIFF
--- a/linux/context/vector/common.yaml
+++ b/linux/context/vector/common.yaml
@@ -9,6 +9,16 @@ sources:
       - load
       - memory
       - network
+    disk:
+      devices:
+        excludes: ["loop*", "sr*", "fd*"]
+    filesystem:
+      devices:
+        excludes: ["/dev/loop*"]
+        includes: ["/dev/*"]
+    network:
+      devices:
+        excludes: ["br*", "docker*", "lo", "veth*"]
 
 sinks:
   vector:


### PR DESCRIPTION
This PR is updating the vector configuration to only collect required metrics