### PR TITLE
Fix DCGM exporter

### DIFF
--- a/linux/context/vector/dcgm-exporter.service
+++ b/linux/context/vector/dcgm-exporter.service
@@ -13,7 +13,7 @@ ExecStart=/bin/bash -c ' \
     --publish 9400:9400 \
     --gpus all \
     --cap-add SYS_ADMIN \
-    nvcr.io/nvidia/k8s/dcgm-exporter:4.1.1-4.0.4-ubuntu22.04'
+    nvidia/dcgm-exporter:4.1.1-4.0.4-ubuntu22.04'
 
 [Install]
 WantedBy=multi-user.target

--- a/linux/context/vector/dcgm-exporter.service
+++ b/linux/context/vector/dcgm-exporter.service
@@ -6,13 +6,14 @@ Requires=docker.service
 [Service]
 TimeoutStartSec=0
 Restart=always
-ExecStart=/usr/bin/docker run --rm \
-  --name dcgm-exporter \
-  --hostname %H \
-  --publish 9400:9400 \
-  --gpus all \
-  --cap-add SYS_ADMIN \
-  nvcr.io/nvidia/k8s/dcgm-exporter:4.1.1-4.0.4-ubuntu22.04
+ExecStart=/bin/bash -c ' \
+  /usr/bin/docker run --rm \
+    --name dcgm-exporter \
+    --hostname $$(hostname -f) \
+    --publish 9400:9400 \
+    --gpus all \
+    --cap-add SYS_ADMIN \
+    nvcr.io/nvidia/k8s/dcgm-exporter:4.1.1-4.0.4-ubuntu22.04'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR is fixing some issues with the DCGM exporter deployment:
- Use dockerhub image instead of nvcr.io: This will ensure we use our docker pull through cache and don't hit any rate limit
- Use `hostname -f` instead of `%H` to get the hostname: Unfortunately, the `%H` variable provided by systemd is checking the hostname when systemd is started, which is not a valid hostname until some services are started. To get the right hostname, we need to use the `hostname` command. This requires to run a sub shell, and so to run our docker command using a shell