### PR TITLE
Use vector instead of fluent-bit to collect logs on qemu images

### DIFF
--- a/linux/context/vector/qemu-cpu.yaml
+++ b/linux/context/vector/qemu-cpu.yaml
@@ -27,6 +27,16 @@ transforms:
     type: remap
     inputs: [logs]
     source: |-
+      # Vector is using the hostname specified in systemd logs. This hostname is
+      # set to `nv-runner` until cloud-init is updating it. As vector is
+      # started after the hostname is set, we override the hostname here with
+      # the updated hostname
+      host, err = get_hostname()
+      if err != null {
+        log("Failed to get hostname: " + err +  ". Defaulting to systemd hostname", level: "error")
+      } else {
+        .host = host
+      }
       # fluent-bit is looking for the hostname key
       .hostname = .host
 

--- a/linux/context/vector/qemu-cpu.yaml
+++ b/linux/context/vector/qemu-cpu.yaml
@@ -1,4 +1,6 @@
 sources:
+  logs:
+    type: journald
   metrics:
     type: host_metrics
     collectors:
@@ -20,6 +22,14 @@ sources:
       devices:
         excludes: ["br*", "docker*", "lo", "veth*"]
 
+transforms:
+  logs_transform:
+    type: remap
+    inputs: [logs]
+    source: |-
+      # fluent-bit is looking for the hostname key
+      .hostname = .host
+
 sinks:
   vector:
     type: vector
@@ -30,3 +40,11 @@ sinks:
     tls:
       enabled: true
       alpn_protocols: ["h2"]
+  fluent-bit:
+    type: http
+    inputs: [logs_transform]
+    uri: https://fb.local.gha-runners.nvidia.com/logs
+    healthcheck:
+      enabled: false
+    encoding:
+      codec: json

--- a/linux/context/vector/qemu-gpu.yaml
+++ b/linux/context/vector/qemu-gpu.yaml
@@ -1,4 +1,6 @@
 sources:
+  logs:
+    type: journald
   metrics:
     type: host_metrics
     collectors:
@@ -23,6 +25,14 @@ sources:
     type: prometheus_scrape
     endpoints: ["http://127.0.0.1:9400/metrics"]
 
+transforms:
+  logs_transform:
+    type: remap
+    inputs: [logs]
+    source: |-
+      # fluent-bit is looking for the hostname key
+      .hostname = .host
+
 sinks:
   vector:
     type: vector
@@ -33,3 +43,11 @@ sinks:
     tls:
       enabled: true
       alpn_protocols: ["h2"]
+  fluent-bit:
+    type: http
+    inputs: [logs_transform]
+    uri: https://fb.local.gha-runners.nvidia.com/logs
+    healthcheck:
+      enabled: false
+    encoding:
+      codec: json

--- a/linux/context/vector/qemu-gpu.yaml
+++ b/linux/context/vector/qemu-gpu.yaml
@@ -30,6 +30,16 @@ transforms:
     type: remap
     inputs: [logs]
     source: |-
+      # Vector is using the hostname specified in systemd logs. This hostname is
+      # set to `nv-runner` until cloud-init is updating it. As vector is
+      # started after the hostname is set, we override the hostname here with
+      # the updated hostname
+      host, err = get_hostname()
+      if err != null {
+        log("Failed to get hostname: " + err +  ". Defaulting to systemd hostname", level: "error")
+      } else {
+        .host = host
+      }
       # fluent-bit is looking for the hostname key
       .hostname = .host
 

--- a/linux/installers/fluent-bit.sh
+++ b/linux/installers/fluent-bit.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+# qemu env is now using vector
+if [ "${NV_RUNNER_ENV}" == "qemu" ]; then
+  echo "NV_RUNNER_ENV is 'qemu'. Skipping Fluent Bit installation."
+  exit 0
+fi
+
 KEYRING="/usr/share/keyrings/fluentbit.gpg"
 APT="/etc/apt/sources.list.d/fluentbit.list"
 

--- a/linux/installers/vector.sh
+++ b/linux/installers/vector.sh
@@ -27,9 +27,13 @@ echo "deb [signed-by=${KEYRING}] \
 sudo apt-get update
 
 sudo apt-get install --no-install-recommends -y vector
-sudo systemctl enable vector
 
 sudo rm -rf "${APT}" "${KEYRING}"
+sudo systemctl stop vector
+sudo systemctl enable vector
+
+# Make sure hostname is set before starting vector
+sudo sed -i '/^After=/ s/$/ systemd-hostnamed.service/' /lib/systemd/system/vector.service
 
 VECTOR_CONFIG_DIR="/etc/vector"
 


### PR DESCRIPTION
This PR is configuring `vector` to collect `systemd` logs and send them to `fluent-bit` on `qemu` images. In addition, this PR is removing the installation of `fluent-bit` on `qemu` images