### PR TITLE
vector: push logs to vector aggregator instead of fluent-bit for qemu env

### DIFF
--- a/linux/context/vector/qemu-cpu.yaml
+++ b/linux/context/vector/qemu-cpu.yaml
@@ -37,24 +37,14 @@ transforms:
       } else {
         .host = host
       }
-      # fluent-bit is looking for the hostname key
-      .hostname = .host
 
 sinks:
   vector:
     type: vector
-    inputs: [metrics]
+    inputs: [logs_transform, metrics]
     address: https://vector.local.gha-runners.nvidia.com
     healthcheck:
       enabled: false
     tls:
       enabled: true
       alpn_protocols: ["h2"]
-  fluent-bit:
-    type: http
-    inputs: [logs_transform]
-    uri: https://fb.local.gha-runners.nvidia.com/logs
-    healthcheck:
-      enabled: false
-    encoding:
-      codec: json

--- a/linux/context/vector/qemu-gpu.yaml
+++ b/linux/context/vector/qemu-gpu.yaml
@@ -40,24 +40,14 @@ transforms:
       } else {
         .host = host
       }
-      # fluent-bit is looking for the hostname key
-      .hostname = .host
 
 sinks:
   vector:
     type: vector
-    inputs: [metrics, gpu_metrics]
+    inputs: [logs_transform, metrics, gpu_metrics]
     address: https://vector.local.gha-runners.nvidia.com
     healthcheck:
       enabled: false
     tls:
       enabled: true
       alpn_protocols: ["h2"]
-  fluent-bit:
-    type: http
-    inputs: [logs_transform]
-    uri: https://fb.local.gha-runners.nvidia.com/logs
-    healthcheck:
-      enabled: false
-    encoding:
-      codec: json


### PR DESCRIPTION
This PR is updating the Vector config to stop sending logs to Fluent Bit and instead send them to the Vector aggregator