### PR TITLE
[ci] add linting with pre-commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,12 +70,12 @@ jobs:
           DRIVER_FLAVOR: ${{ matrix.DRIVER_FLAVOR }}
           OS: ${{ matrix.OS }}
           RUNNER_ENV: ${{ matrix.ENV }}
-        # The `exec` command is used to help forward signals to the child process.
-        # This helps ensure Packer's AWS resources get removed when the job is cancelled.
-        #
-        # The `parallel-builds=1` flag ensures that the build jobs are run
-        # serially. This allows the "preprovision" builds to run before the
-        # actual builds since they are defined first in the templates.
+      # The `exec` command is used to help forward signals to the child process.
+      # This helps ensure Packer's AWS resources get removed when the job is cancelled.
+      #
+      # The `parallel-builds=1` flag ensures that the build jobs are run
+      # serially. This allows the "preprovision" builds to run before the
+      # actual builds since they are defined first in the templates.
       - name: Build image
         run: |
           packer init .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,15 +23,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Check Packer files formatting
         run: packer fmt -check -recursive .
-  shellcheck:
+  checks:
     runs-on: ubuntu-latest
-    container:
-      image: koalaman/shellcheck-alpine:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Run shellcheck on shell scripts
-        run: find . -name "*.sh" | xargs -n 1 shellcheck --color=always
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
   gc:
     uses: ./.github/workflows/gc.yaml
     with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.6
+    hooks:
+      - id: ruff-format
+        args: ["--config", "pyproject.toml"]
+      - id: ruff
+        args: ["--config", "pyproject.toml", "--fix"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 'v5.0.0'
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-builtin-literals
+      - id: debug-statements
+      - id: requirements-txt-fixer
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--rcfile", ".shellcheckrc"]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,19 @@
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+  document-start: disable
+  line-length:
+    max: 200
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false

--- a/gc/collectors/gc.py
+++ b/gc/collectors/gc.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 
-
 DEFAULT_BRANCH_NAME = "main"
 
 
@@ -15,9 +14,7 @@ class GarbageCollector(ABC):
         print(f"{self.removal_action} {resource_name}: {resource_id}")
 
     def run(self) -> None:
-        print(
-            f"Running {self.collector_name}: dry_run={self.dry_run}, region={self.region}"
-        )
+        print(f"Running {self.collector_name}: dry_run={self.dry_run}, region={self.region}")
         self._run()
 
     @abstractmethod

--- a/gc/collectors/image_name.py
+++ b/gc/collectors/image_name.py
@@ -4,10 +4,7 @@ import os.path
 import subprocess
 from typing import Optional
 
-
-DESERIALIZE_PATH = os.path.join(
-    os.path.dirname(__file__), "..", "..", "ci", "image-name", "deserialize.sh"
-)
+DESERIALIZE_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "ci", "image-name", "deserialize.sh")
 
 
 @dataclasses.dataclass

--- a/gc/main.py
+++ b/gc/main.py
@@ -1,11 +1,11 @@
 import argparse
-import subprocess
 import json
-import yaml
-from os import path, getenv
+import subprocess
+from os import getenv, path
 
-from collectors.ecr import ECRGarbageCollector
+import yaml
 from collectors.amis import AMIGarbageCollector
+from collectors.ecr import ECRGarbageCollector
 from collectors.gc import DEFAULT_BRANCH_NAME
 from github import Github
 
@@ -14,15 +14,9 @@ def load_current_images(runner_env: str) -> list[str]:
     """
     Loads the currently supported images from the matrix and returns them as a list.
     """
-    compute_matrix_path = path.join(
-        path.dirname(__file__), "..", "ci", "compute-matrix.sh"
-    )
-    compute_image_name_path = path.join(
-        path.dirname(__file__), "..", "ci", "image-name", "serialize.sh"
-    )
-    result = subprocess.run(
-        compute_matrix_path, cwd="..", stdout=subprocess.PIPE, text=True, check=True
-    )
+    compute_matrix_path = path.join(path.dirname(__file__), "..", "ci", "compute-matrix.sh")
+    compute_image_name_path = path.join(path.dirname(__file__), "..", "ci", "image-name", "serialize.sh")
+    result = subprocess.run(compute_matrix_path, cwd="..", stdout=subprocess.PIPE, text=True, check=True)
     matrix: list[dict[str, str]] = json.loads(result.stdout)["include"]
     images = []
     for entry in matrix:

--- a/gc/requirements.txt
+++ b/gc/requirements.txt
@@ -1,8 +1,8 @@
+black
 boto3
 boto3-stubs[boto3,ec2,ecr-public]
-types-python-dateutil
-black
 mypy
-pyyaml
-types-PyYAML
 PyGithub
+pyyaml
+types-python-dateutil
+types-PyYAML

--- a/linux/installers/docker.sh
+++ b/linux/installers/docker.sh
@@ -7,6 +7,7 @@ APT="/etc/apt/sources.list.d/docker.list"
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o "${KEYRING}"
 sudo chmod a+r "${KEYRING}"
 
+# shellcheck disable=SC1091
 echo \
   "deb [arch=\"$(dpkg --print-architecture)\" signed-by=${KEYRING}] https://download.docker.com/linux/ubuntu \
   \"$(. /etc/os-release && echo "$VERSION_CODENAME")\" stable" | \

--- a/linux/installers/python.sh
+++ b/linux/installers/python.sh
@@ -9,6 +9,6 @@ sudo apt-get install -y --no-install-recommends \
   python3-venv
 
 
-# Prepend $HOME/.local/bin /etc/environemnt PATH
+# Prepend $HOME/.local/bin /etc/environment PATH
 # Adding this dir to PATH will make installed pip commands are immediately available.
 sudo sed -i "/^PATH=/ s|=\"|=\"$HOME/.local/bin:|" /etc/environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.codespell]
+builtin = "clear"
+quiet-level = 3
+
+[tool.ruff]
+fix = true
+indent-width = 4
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # pyflakes
+    "F",
+    # isort
+    "I",
+    # numpy
+    "NPY",
+    # flake8-bugbear
+    "B"
+]

--- a/windows/context/envvars.ps1
+++ b/windows/context/envvars.ps1
@@ -28,7 +28,7 @@ function Set-MachineEnvironmentVariable {
 
     $check = [Environment]::GetEnvironmentVariable("${Variable}", [EnvironmentVariableTarget]::Machine)
     if ($check -And $check -icontains "${Value}") {
-        Write-Warning "Succesfully set ${Variable} = '${Value}'"
+        Write-Warning "Successfully set ${Variable} = '${Value}'"
         return
     }
     else {


### PR DESCRIPTION
I was looking through this repo and noticed that it contains some non-trivial Python code that isn't currently covered by any static analysis.

This PR proposes adding configuration to run the following linters via `pre-commit`:

* `codespell` = catches English typos
* `ruff` = auto-formatting and linting for Python code
* `shellcheck` = linting for shell scripts (this repo already had that running, this just switches it to `pre-commit`)
* various built-in `pre-commit` hooks, like those for fixing files that don't end in a newline

Hopefully these changes will give us a bit more release confidence in changes that touch the various scripts in this repo.