### PR TITLE
[ci] remove black from gc workflow

### DIFF
--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -44,8 +44,6 @@ jobs:
         run: pip install -r requirements.txt
       - name: Check mypy
         run: mypy main.py collectors/*.py
-      - name: Check black
-        run: black --check main.py collectors/*.py
       - name: Run garbage collection
         run: python main.py --dry-run="${DRY_RUN}"
         env:


### PR DESCRIPTION
In #124, because of other unrelated CI and my own lack of carefulness, I missed that `black` is run as part of the "garbage collection" workflow, and that that check was failing.

#124 introduced `ruff-format` which does the same thing as `black`. This proposes removing uses of `black` (as RAPIDS is planning to: https://github.com/rapidsai/build-planning/issues/130).

## Notes for Reviewers

I'll merge this with `[skip ci]` to avoid a build of new images, similar to #124.